### PR TITLE
down grade to got @9.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "cheerio": "^1.0.0-rc.3",
     "ejs": "^3.0.1",
     "escape-goat": "^2.1.1",
-    "got": "^10.0.3",
+    "got": "9.6.0",
     "http-proxy-agent": "^3.0.0",
     "https-proxy-agent": "^4.0.0",
     "iconv-lite": "^0.5.0",


### PR DESCRIPTION
downgrade to got@9.6.0
because the unexpected error even just `require('got')`
```js
GotError: read ECONNRESET
    at onError (/home/fengkx/project/NodeRSSBot/node_modules/got/dist/source/request-as-event-emitter.js:138:29)
    at handleRequest (/home/fengkx/project/NodeRSSBot/node_modules/got/dist/source/request-as-event-emitter.js:171:17)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at TLSWrap.onStreamRead (internal/stream_base_commons.js:201:27)
```