### PR TITLE
Add An Environment Value For Custom API Base

### DIFF
--- a/app.json
+++ b/app.json
@@ -32,6 +32,10 @@
             "description": "Telegram Bot Token from @BotFather",
             "required": true
         },
+        "TELEGRAM_API_BASE": {
+            "description": "Telegram API Base URL",
+            "required": false
+        },
         "DATABASE_URL": {
             "description": "connection string of other c/s dbms",
             "required": false

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@cjsa/clean-stack": "^4.2.0",
     "@sentry/node": "^10.5.0",
+    "@typescript-eslint/parser": "^8.41.0",
     "camaro": "^6.2.3",
     "cross-env": "^10.0.0",
     "ejs": "^3.1.10",

--- a/source/config.ts
+++ b/source/config.ts
@@ -43,7 +43,8 @@ export const config: Omit<Config, 'PKG_ROOT'> = {
         .map((id) => Number(id)),
     auto_migrate: env.get('AUTO_MIGRATE').default(1).asBool(),
     sentry_dsn: env.get('SENTRY_DSN').default('').asString(),
-    enable_throttle: env.get('ENABLE_THROTTLE').default(0).asBool()
+    enable_throttle: env.get('ENABLE_THROTTLE').default(0).asBool(),
+    telegram_api_base: env.get('TELEGRAM_API_BASE').default('https://api.telegram.org').asString()
 };
 Object.defineProperty(config, 'PKG_ROOT', {
     enumerable: false,

--- a/source/config.ts
+++ b/source/config.ts
@@ -44,7 +44,10 @@ export const config: Omit<Config, 'PKG_ROOT'> = {
     auto_migrate: env.get('AUTO_MIGRATE').default(1).asBool(),
     sentry_dsn: env.get('SENTRY_DSN').default('').asString(),
     enable_throttle: env.get('ENABLE_THROTTLE').default(0).asBool(),
-    telegram_api_base: env.get('TELEGRAM_API_BASE').default('https://api.telegram.org').asString()
+    telegram_api_base: env
+        .get('TELEGRAM_API_BASE')
+        .default('https://api.telegram.org')
+        .asString()
 };
 Object.defineProperty(config, 'PKG_ROOT', {
     enumerable: false,

--- a/source/index.ts
+++ b/source/index.ts
@@ -22,7 +22,15 @@ import {
 import importReply from './controlers/import-reply';
 import { config } from './config';
 import agent from './utils/agent';
-const { token, view_all, lang, item_num, db_path, not_send, telegram_api_base } = config;
+const {
+    token,
+    view_all,
+    lang,
+    item_num,
+    db_path,
+    not_send,
+    telegram_api_base
+} = config;
 
 import getUrl from './middlewares/get-url';
 import getUrlByTitle from './middlewares/get-url-by-title';

--- a/source/index.ts
+++ b/source/index.ts
@@ -22,7 +22,7 @@ import {
 import importReply from './controlers/import-reply';
 import { config } from './config';
 import agent from './utils/agent';
-const { token, view_all, lang, item_num, db_path, not_send } = config;
+const { token, view_all, lang, item_num, db_path, not_send, telegram_api_base } = config;
 
 import getUrl from './middlewares/get-url';
 import getUrlByTitle from './middlewares/get-url-by-title';
@@ -49,6 +49,7 @@ import { encodeUrl } from './utils/urlencode';
 const bot = new Telegraf(token, {
     telegram: {
         // Telegram options
+        apiRoot: telegram_api_base, // Custom API Base
         agent: agent?.https // https.Agent instance, allows custom proxy, certificate, keep alive, etc.
     }
 });

--- a/source/types/config.d.ts
+++ b/source/types/config.d.ts
@@ -1,5 +1,6 @@
 export type Config = {
     token: string;
+    telegram_api_base: string;
     proxy: {
         protocol: string;
         host: string;


### PR DESCRIPTION
Add an env val for tg api base.

Value: `TELEGRAM_API_BASE`
Required: `false`
Default: `https://api.telegram.org`
Sample: `https://tgapi.example.com`

I've built a test image and proven it works.